### PR TITLE
make fedora (current) docker image runnable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM scratch
 MAINTAINER Patrick Uiterwijk <patrick@puiterwijk.org>
 ADD fedora-23-20160523.tar.xz /
+CMD ["/bin/bash"]


### PR DESCRIPTION
Hello,

I'm using https://github.com/swipely/docker-api to create fedora based package.

It appears that 

* ubuntu
* debian
* centos

are runnable (I **can** create `container`) but not **fedora**.

It's seems to be that image is not interactively runnable