### PR TITLE
Export container environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM scratch
 MAINTAINER \
 [Adam Miller <maxamillion@fedoraproject.org>] \
 [Patrick Uiterwijk <patrick@puiterwijk.org>]
+ENV container=oci
 ADD fedora-rawhide-20150901.tar.xz /


### PR DESCRIPTION
systemd expects that system container exports environment variable
"container". I think this base image should allow people to build
all sorts of layered images. Some of them may end up running
systemd. Let's export env variable in base image so our users don't have
to.

https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/