### PR TITLE
Add default command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,6 @@ MAINTAINER \
 [Patrick Uiterwijk <patrick@puiterwijk.org>]
 ENV container=oci
 ADD fedora-rawhide-20150901.tar.xz /
+
+# Add default image command
+CMD ["/bin/bash"]


### PR DESCRIPTION
Before this change:

`docker run -it fedora`

gives: `Error response from daemon: No command specified.`

so we have to provide a command:

`docker run -it fedora /bin/bash`

After this change both will work.