### PR TITLE
Configure xz to use all CPU cores

### DIFF
--- a/prep-docker-brew-branch.sh
+++ b/prep-docker-brew-branch.sh
@@ -7,6 +7,9 @@
 #
 # [0] - https://github.com/fedora-cloud/docker-brew-fedora
 
+# use all CPU cores when compressing unless XZ_DEFAULTS is already defined
+export XZ_DEFAULTS="${XZ_DEFAULTS:--T 0}"
+
 f_ctrl_c() {
     printf "\n*** Exiting ***\n"
     exit $?


### PR DESCRIPTION
Speedup compression tasks considerably by telling xz to use all
available cores.

This change happens unless user already defined XZ_DEFAULTS
environment variable.

Fixes: #64